### PR TITLE
Add action to post image to PR comments

### DIFF
--- a/.github/actions/build-publish-docker/action.yml
+++ b/.github/actions/build-publish-docker/action.yml
@@ -117,6 +117,11 @@ runs:
           build-args: ${{ inputs.build-args }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
+    - name: Post image name to PR comments
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        message: |
+          📀 PR image is ready: oneclickpr-${{ steps.findPr.outputs.pr }}-${{ env.BUILD_NUMBER }}
     - name: Build and push Release
       if: contains(github.ref, 'release')
       uses: docker/build-push-action@v3


### PR DESCRIPTION
# Description

This takes much time to go deep into the action log to find the image number. So I suggest posting this important info in PR comments.

 I believe any repo inheriting this set of actions will benefit from this minor change.