### PR TITLE
fix(bump-version): add custom tag to library pr bump version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -79,6 +79,7 @@ jobs:
         with:
           github_token: ${{ secrets.token }}
           custom_tag: pr-${{ env.BUILD_NUMBER }}
+          tag_prefix: ""
       - name: Create a GitHub release PR (service)
         if: ${{ inputs.is-library == false && (github.ref != 'refs/heads/master' || github.ref != 'refs/heads/main') && steps.findPr.outputs.number > 0 }}
         uses: actions/create-release@v1

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -78,6 +78,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.0
         with:
           github_token: ${{ secrets.token }}
+          custom_tag: pr-${{ env.BUILD_NUMBER }}
       - name: Create a GitHub release PR (service)
         if: ${{ inputs.is-library == false && (github.ref != 'refs/heads/master' || github.ref != 'refs/heads/main') && steps.findPr.outputs.number > 0 }}
         uses: actions/create-release@v1


### PR DESCRIPTION
Currently any module that uses the `is-library`, will release a new "production" version for any open PR builds. Adding a `pr-` prefix would help distinguish actual releases from "development releases" 