### PR TITLE
feat: make it possible to not create a release and just tag

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -10,6 +10,10 @@ on:
         required: false
         default: false
         type: boolean
+      create-release:
+        required: false
+        default: true
+        type: boolean
     secrets:
       token:
         required: true
@@ -46,7 +50,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v5.6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - if: ${{ inputs.is-library == false && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') }}
+      - if: ${{ inputs.create-release == true && inputs.is-library == false && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') }}
         name: Create a GitHub release (service)
         uses: actions/create-release@v1
         env:
@@ -55,7 +59,7 @@ jobs:
           tag_name: ${{ steps.tag_version.outputs.new_tag }}
           release_name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
-      - if: ${{ inputs.is-library == true && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') }}
+      - if: ${{ inputs.create-release == true && inputs.is-library == true && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') }}
         name: Create a GitHub release (library)
         uses: actions/create-release@v1
         env:
@@ -81,7 +85,7 @@ jobs:
           custom_tag: pr-${{ env.BUILD_NUMBER }}
           tag_prefix: ""
       - name: Create a GitHub release PR (service)
-        if: ${{ inputs.is-library == false && (github.ref != 'refs/heads/master' || github.ref != 'refs/heads/main') && steps.findPr.outputs.number > 0 }}
+        if: ${{ inputs.create-release == true && inputs.is-library == false && (github.ref != 'refs/heads/master' || github.ref != 'refs/heads/main') && steps.findPr.outputs.number > 0 }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.token }}
@@ -90,7 +94,7 @@ jobs:
           release_name: Release ${{ steps.tag_version_pr.outputs.new_tag }}
           body: ${{ steps.tag_version_pr.outputs.changelog }}
       - name: Create a GitHub release PR (library)
-        if: ${{ inputs.is-library == true && (github.ref != 'refs/heads/master' || github.ref != 'refs/heads/main') && steps.findPr.outputs.number > 0 }}
+        if: ${{ inputs.create-release == true && inputs.is-library == true && (github.ref != 'refs/heads/master' || github.ref != 'refs/heads/main') && steps.findPr.outputs.number > 0 }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.token }}
@@ -111,7 +115,7 @@ jobs:
         with:
           github_token: ${{ secrets.token }}
       - name: Create a GitHub release branch
-        if: contains(github.ref, 'release')
+        if: ${{inputs.create-release == true && contains(github.ref, 'release') }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.token }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/bump-version.yml` file to include a new `create-release` input and modifies the conditions for creating GitHub releases based on this input. The most important changes include the addition of the `create-release` input and updates to the conditional statements in the workflow.

Additions to inputs:

* Added `create-release` input with default value set to `true` in the `on:` section. (`.github/workflows/bump-version.yml`)

Updates to conditional statements:

* Modified conditional statements to check the value of `create-release` input before creating GitHub releases for services and libraries. (`.github/workflows/bump-version.yml`) [[1]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392L49-R53) [[2]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392L58-R62) [[3]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392L84-R88) [[4]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392L93-R97) [[5]](diffhunk://#diff-69dbd9a1529c6dcabcd45dea53b2056cb801e4d214fb9d03cd60748b2b082392L114-R118)