### PR TITLE
feat(golang-ci): add go-test-tags input for build tag filtering

### DIFF
--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -41,11 +41,16 @@ on:
         required: false
         type: string
         default: "ubuntu-latest"
+      go-test-tags:
+        description: "Go build tags for test filtering (e.g. 'integration' or 'integration,e2e')"
+        required: false
+        type: string
+        default: ""
       dockerhub_username:
         description: "dockerhub username"
         required: false
         type: string
-        default: "tazerr"        
+        default: "tazerr"
     secrets:
       FT_SSH_KEY:
         required: true
@@ -170,7 +175,7 @@ jobs:
         fi
 
     - name: Run Test
-      run: MYSQL_VERSION=${{ inputs.go-test-mysql-version }} gotestsum --junitfile test-reports/report.xml -- -timeout ${{ inputs.go-test-timeout }} -parallel=5 -covermode=atomic -coverprofile=cover.out ./...
+      run: MYSQL_VERSION=${{ inputs.go-test-mysql-version }} gotestsum --junitfile test-reports/report.xml -- -timeout ${{ inputs.go-test-timeout }} -parallel=5 -covermode=atomic -coverprofile=cover.out ${{ inputs.go-test-tags && format('-tags={0}', inputs.go-test-tags) || '' }} ./...
 
     - name: Test Report
       uses: dorny/test-reporter@v1


### PR DESCRIPTION
## Summary

- Adds `go-test-tags` optional string input to `golang-ci.yml` for Go build tag filtering (e.g. `integration`, `integration,e2e`)
- Conditionally injects `-tags=<value>` into the `gotestsum` command when the input is provided
- Fully backwards-compatible — callers that don't pass `go-test-tags` get identical behavior to today

## Context

Enables test categorization via Go build tags (`unit`, `integration`, `e2e`). Consumer workflows can pass tags to control which test suites run, supporting draft-PR vs ready-PR gating strategies.

## Test plan

- [ ] Verify existing workflows that don't pass `go-test-tags` still work (empty default → no `-tags` flag)
- [ ] Test with `go-test-tags: integration` — confirm `-tags=integration` appears in the command
- [ ] Test with `go-test-tags: integration,e2e` — confirm `-tags=integration,e2e` appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)