### PR TITLE
fix: automatically pass BUILD_VERSION to Docker builds

### DIFF
--- a/.github/actions/build-publish-docker/action.yml
+++ b/.github/actions/build-publish-docker/action.yml
@@ -150,7 +150,9 @@ runs:
         outputs: type=image,push=true,oci-mediatypes=true
         tags: ${{ steps.login-ecr.outputs.registry }}/${{inputs.image}}:${{inputs.tag-prefix}}oneclick-${{ env.BUILD_NUMBER }}-${{ steps.platform.outputs.arch }}
         file: ${{inputs.dockerfile}}
-        build-args: ${{ inputs.build-args }}
+        build-args: |
+            BUILD_VERSION=${{ env.BUILD_NUMBER }}
+            ${{ inputs.build-args }}
         cache-from: type=gha,scope=${{ inputs.image }}-${{ steps.platform.outputs.suffix }}
         cache-to: type=gha,scope=${{ inputs.image }}-${{ steps.platform.outputs.suffix }},mode=max
     - name: Build and push latest
@@ -165,7 +167,9 @@ runs:
         outputs: type=image,push=true,oci-mediatypes=true
         tags: ${{ steps.login-ecr.outputs.registry }}/${{inputs.image}}:${{inputs.tag-prefix}}latest-${{ steps.platform.outputs.arch }}
         file: ${{inputs.dockerfile}}
-        build-args: ${{ inputs.build-args }}
+        build-args: |
+            BUILD_VERSION=${{ env.BUILD_NUMBER }}
+            ${{ inputs.build-args }}
         cache-from: type=gha,scope=${{ inputs.image }}-${{ steps.platform.outputs.suffix }}
         cache-to: type=gha,scope=${{ inputs.image }}-${{ steps.platform.outputs.suffix }},mode=max
     - name: Build and push PR
@@ -180,7 +184,9 @@ runs:
         outputs: type=image,push=true,oci-mediatypes=true
         tags: ${{ steps.login-ecr.outputs.registry }}/${{inputs.image}}:${{inputs.tag-prefix}}oneclickpr-${{ steps.findPr.outputs.pr }}-${{ env.BUILD_NUMBER }}-${{ steps.platform.outputs.arch }}
         file: ${{inputs.dockerfile}}
-        build-args: ${{ inputs.build-args }}
+        build-args: |
+            BUILD_VERSION=${{ env.BUILD_NUMBER }}
+            ${{ inputs.build-args }}
         cache-from: type=gha,scope=${{ inputs.image }}-${{ steps.platform.outputs.suffix }}
         cache-to: type=gha,scope=${{ inputs.image }}-${{ steps.platform.outputs.suffix }},mode=max
     - name: Comment oneclick PR tag
@@ -204,7 +210,9 @@ runs:
         outputs: type=image,push=true,oci-mediatypes=true
         tags: ${{ steps.login-ecr.outputs.registry }}/${{inputs.image}}:${{inputs.tag-prefix}}oneclickrelease-${{ env.BUILD_NUMBER }}-${{ steps.platform.outputs.arch }}
         file: ${{inputs.dockerfile}}
-        build-args: ${{ inputs.build-args }}
+        build-args: |
+            BUILD_VERSION=${{ env.BUILD_NUMBER }}
+            ${{ inputs.build-args }}
         cache-from: type=gha,scope=${{ inputs.image }}-${{ steps.platform.outputs.suffix }}
         cache-to: type=gha,scope=${{ inputs.image }}-${{ steps.platform.outputs.suffix }},mode=max
     - name: Set outputs


### PR DESCRIPTION
## Summary
- Injects `BUILD_VERSION` (computed as `run_number + start-build-from`) as a Docker build arg in all four build steps (master, latest, PR, release)
- Services whose Dockerfile accepts `BUILD_VERSION` via ldflags will now report the correct version automatically
- Existing `build-args` from callers are preserved (appended after `BUILD_VERSION`)

## Context
The crm-api `/version` endpoint was returning `0` in staging because `BUILD_VERSION` was never passed to the Docker build. Rather than fixing this per-caller, this change centralises it in the shared action so all services benefit.

## Test plan
- [ ] Trigger a crm-api CI build and verify the Docker image has the correct version baked in
- [ ] Verify `/version` returns a non-zero build number after deployment
- [ ] Confirm existing services that pass their own `build-args` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)