### PR TITLE
feat: added terraform validation ci

### DIFF
--- a/.github/workflows/terraform-v0-ci.yml
+++ b/.github/workflows/terraform-v0-ci.yml
@@ -55,13 +55,17 @@ jobs:
         with:
           terraform_version: "0.11.13"
 
-      - name: Build terraform-provider-kubernetes
+      - name: Build pinned Terraform providers
         run: |
           git clone https://github.com/fasttrack-solutions/terraform-provider-kubernetes /tmp/terraform-provider-kubernetes
           cd /tmp/terraform-provider-kubernetes
           make build
-          mkdir -p ~/.terraform.d/plugins/
-          find "$GOPATH/bin" /tmp/terraform-provider-kubernetes -maxdepth 6 -type f -name 'terraform-provider-kubernetes*' 2>/dev/null | head -n 1 | xargs -I{} install -m 0755 {} ~/.terraform.d/plugins/terraform-provider-kubernetes
+          mkdir -p ~/.terraform.d/plugins/linux_amd64/
+          p="$(find "$GOPATH/bin" /tmp/terraform-provider-kubernetes -maxdepth 6 -type f -name 'terraform-provider-kubernetes*' 2>/dev/null | head -n 1)"
+          if [ -z "$p" ]; then echo "ERROR: terraform-provider-kubernetes binary not found after build" && exit 1; fi
+          install -m 0755 "$p" ~/.terraform.d/plugins/linux_amd64/terraform-provider-kubernetes
+          echo "Installed provider from $p"
+          ls -la ~/.terraform.d/plugins/linux_amd64/
 
       - name: Validate all paths
         env:

--- a/.github/workflows/terraform-v0-ci.yml
+++ b/.github/workflows/terraform-v0-ci.yml
@@ -33,8 +33,13 @@ jobs:
         run: |
           for path in $(echo "$PATHS_JSON" | jq -r '.[]'); do
             echo "::group::$path"
-            (cd "$path" && terraform fmt -check .) || echo "::warning::Format issues in $path"
+            output="$(cd "$path" && terraform fmt -check . 2>&1)" && status=0 || status=$?
+            echo "$output"
             echo "::endgroup::"
+            if [ "$status" -ne 0 ]; then
+              echo "::warning::Format issues in $path"
+              echo "$output"
+            fi
           done
 
   validate:
@@ -63,19 +68,22 @@ jobs:
           go build -o ~/.terraform.d/plugins/linux_amd64/terraform-provider-kubernetes
           ls -la ~/.terraform.d/plugins/linux_amd64/
 
-      - name: Validate all paths
+      - name: Validate
         env:
           PATHS_JSON: ${{ inputs.paths }}
         run: |
           failed=""
           for path in $(echo "$PATHS_JSON" | jq -r '.[]'); do
             echo "::group::$path"
-            if ! (cd "$path" && terraform init -backend=false && terraform validate -check-variables=false); then
-              failed="$failed $path"
-            fi
+            output="$(cd "$path" && terraform init -backend=false 2>&1 && terraform validate -check-variables=false 2>&1)" && status=0 || status=$?
+            echo "$output"
             echo "::endgroup::"
+            if [ "$status" -ne 0 ]; then
+              failed="$failed $path"
+              echo "::error::$path failed validation:"
+              echo "$output" | grep -i -A2 'error'
+            fi
           done
           if [ -n "$failed" ]; then
-            echo "::error::Validation failed for:$failed"
             exit 1
           fi

--- a/.github/workflows/terraform-v0-ci.yml
+++ b/.github/workflows/terraform-v0-ci.yml
@@ -37,8 +37,7 @@ jobs:
             echo "$output"
             echo "::endgroup::"
             if [ "$status" -ne 0 ]; then
-              echo "::warning::Format issues in $path"
-              echo "$output"
+              echo "::warning::$path format issues"
             fi
           done
 
@@ -80,8 +79,7 @@ jobs:
             echo "::endgroup::"
             if [ "$status" -ne 0 ]; then
               failed="$failed $path"
-              echo "::error::$path failed validation:"
-              echo "$output" | grep -i -A2 'error'
+              echo "::error::$path validation failed"
             fi
           done
           if [ -n "$failed" ]; then

--- a/.github/workflows/terraform-v0-ci.yml
+++ b/.github/workflows/terraform-v0-ci.yml
@@ -3,8 +3,8 @@ name: Terraform v0 CI
 on:
   workflow_call:
     inputs:
-      path:
-        description: "Path to Terraform 0.11.13 directory"
+      paths:
+        description: "JSON array of paths to Terraform 0.11 directories"
         type: string
         required: true
       runner:
@@ -27,9 +27,15 @@ jobs:
         with:
           terraform_version: "0.11.13"
 
-      - name: Terraform Format Check
-        run: terraform fmt -check .
-        working-directory: ${{ inputs.path }}
+      - name: Check formatting
+        env:
+          PATHS_JSON: ${{ inputs.paths }}
+        run: |
+          for path in $(echo "$PATHS_JSON" | jq -r '.[]'); do
+            echo "::group::$path"
+            (cd "$path" && terraform fmt -check .) || echo "::warning::Format issues in $path"
+            echo "::endgroup::"
+          done
 
   validate:
     name: Validate
@@ -43,10 +49,19 @@ jobs:
         with:
           terraform_version: "0.11.13"
 
-      - name: Terraform Init
-        run: terraform init -backend=false
-        working-directory: ${{ inputs.path }}
-
-      - name: Terraform Validate
-        run: terraform validate -check-variables=false
-        working-directory: ${{ inputs.path }}
+      - name: Validate all paths
+        env:
+          PATHS_JSON: ${{ inputs.paths }}
+        run: |
+          failed=""
+          for path in $(echo "$PATHS_JSON" | jq -r '.[]'); do
+            echo "::group::$path"
+            if ! (cd "$path" && terraform init -backend=false && terraform validate -check-variables=false); then
+              failed="$failed $path"
+            fi
+            echo "::endgroup::"
+          done
+          if [ -n "$failed" ]; then
+            echo "::error::Validation failed for:$failed"
+            exit 1
+          fi

--- a/.github/workflows/terraform-v0-ci.yml
+++ b/.github/workflows/terraform-v0-ci.yml
@@ -55,16 +55,12 @@ jobs:
         with:
           terraform_version: "0.11.13"
 
-      - name: Build pinned Terraform providers
+      - name: Build pinned Kubernetes Terraform provider
         run: |
+          mkdir -p ~/.terraform.d/plugins/linux_amd64/
           git clone https://github.com/fasttrack-solutions/terraform-provider-kubernetes /tmp/terraform-provider-kubernetes
           cd /tmp/terraform-provider-kubernetes
-          make build
-          mkdir -p ~/.terraform.d/plugins/linux_amd64/
-          p="$(find "$GOPATH/bin" /tmp/terraform-provider-kubernetes -maxdepth 6 -type f -name 'terraform-provider-kubernetes*' 2>/dev/null | head -n 1)"
-          if [ -z "$p" ]; then echo "ERROR: terraform-provider-kubernetes binary not found after build" && exit 1; fi
-          install -m 0755 "$p" ~/.terraform.d/plugins/linux_amd64/terraform-provider-kubernetes
-          echo "Installed provider from $p"
+          go build -o ~/.terraform.d/plugins/linux_amd64/terraform-provider-kubernetes
           ls -la ~/.terraform.d/plugins/linux_amd64/
 
       - name: Validate all paths

--- a/.github/workflows/terraform-v0-ci.yml
+++ b/.github/workflows/terraform-v0-ci.yml
@@ -14,7 +14,7 @@ on:
         default: "ubuntu-latest"
 
 jobs:
-  fmt:
+  format:
     name: Format Check
     runs-on: ${{ inputs.runner }}
     continue-on-error: true
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "0.11.13"
+          terraform_version: "0.11.15"
 
       - name: Build pinned Kubernetes Terraform provider
         run: |

--- a/.github/workflows/terraform-v0-ci.yml
+++ b/.github/workflows/terraform-v0-ci.yml
@@ -44,10 +44,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "~1.25"
+          cache: false
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "0.11.13"
+
+      - name: Build terraform-provider-kubernetes
+        run: |
+          git clone https://github.com/fasttrack-solutions/terraform-provider-kubernetes /tmp/terraform-provider-kubernetes
+          cd /tmp/terraform-provider-kubernetes
+          make build
+          mkdir -p ~/.terraform.d/plugins/
+          find "$GOPATH/bin" /tmp/terraform-provider-kubernetes -maxdepth 6 -type f -name 'terraform-provider-kubernetes*' 2>/dev/null | head -n 1 | xargs -I{} install -m 0755 {} ~/.terraform.d/plugins/terraform-provider-kubernetes
 
       - name: Validate all paths
         env:

--- a/.github/workflows/terraform-v0-ci.yml
+++ b/.github/workflows/terraform-v0-ci.yml
@@ -1,0 +1,52 @@
+name: Terraform v0 CI
+
+on:
+  workflow_call:
+    inputs:
+      path:
+        description: "Path to Terraform 0.11.13 directory"
+        type: string
+        required: true
+      runner:
+        description: "Runner to use"
+        type: string
+        required: false
+        default: "ubuntu-latest"
+
+jobs:
+  fmt:
+    name: Format Check
+    runs-on: ${{ inputs.runner }}
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "0.11.13"
+
+      - name: Terraform Format Check
+        run: terraform fmt -check .
+        working-directory: ${{ inputs.path }}
+
+  validate:
+    name: Validate
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "0.11.13"
+
+      - name: Terraform Init
+        run: terraform init -backend=false
+        working-directory: ${{ inputs.path }}
+
+      - name: Terraform Validate
+        run: terraform validate -check-variables=false
+        working-directory: ${{ inputs.path }}

--- a/.github/workflows/terraform-v0-ci.yml
+++ b/.github/workflows/terraform-v0-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "0.11.13"
+          terraform_version: "0.11.15"
 
       - name: Check formatting
         env:

--- a/.github/workflows/terraform-v1-ci.yml
+++ b/.github/workflows/terraform-v1-ci.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Install Trivy
         run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.69.3
 
       - name: Scan all paths
         env:

--- a/.github/workflows/terraform-v1-ci.yml
+++ b/.github/workflows/terraform-v1-ci.yml
@@ -47,8 +47,7 @@ jobs:
             echo "$output"
             echo "::endgroup::"
             if [ "$status" -ne 0 ]; then
-              echo "::warning::Format issues in $path"
-              echo "$output"
+              echo "::warning::$path format issues"
             fi
           done
 
@@ -64,7 +63,7 @@ jobs:
         with:
           terraform_version: ${{ inputs.terraform_version }}
 
-      - name: Validate all paths
+      - name: Validate
         env:
           PATHS_JSON: ${{ inputs.paths }}
         run: |
@@ -76,8 +75,7 @@ jobs:
             echo "::endgroup::"
             if [ "$status" -ne 0 ]; then
               failed="$failed $path"
-              echo "::error::$path failed validation:"
-              echo "$output" | grep -i -A2 'error'
+              echo "::error::$path validation failed"
             fi
           done
           if [ -n "$failed" ]; then
@@ -117,7 +115,7 @@ jobs:
           TFLINT_EOF
           tflint --init --config /tmp/.tflint.hcl
 
-      - name: Lint all paths
+      - name: Lint
         env:
           PATHS_JSON: ${{ inputs.paths }}
         run: |
@@ -129,8 +127,7 @@ jobs:
             echo "::endgroup::"
             if [ "$status" -ne 0 ]; then
               failed="$failed $path"
-              echo "::error::$path has lint issues:"
-              echo "$output" | grep -i -A2 'error\|warning'
+              echo "::error::$path has lint issues"
             fi
           done
           if [ -n "$failed" ]; then
@@ -162,8 +159,7 @@ jobs:
             echo "::endgroup::"
             if [ "$status" -ne 0 ]; then
               failed="$failed $path"
-              echo "::error::$path has security findings:"
-              echo "$output" | grep -i -A2 'failure\|critical\|high'
+              echo "::error::$path has security findings"
             fi
           done
           if [ -n "$failed" ]; then

--- a/.github/workflows/terraform-v1-ci.yml
+++ b/.github/workflows/terraform-v1-ci.yml
@@ -43,8 +43,13 @@ jobs:
         run: |
           for path in $(echo "$PATHS_JSON" | jq -r '.[]'); do
             echo "::group::$path"
-            terraform -chdir="$path" fmt -check -recursive || echo "::warning::Format issues in $path"
+            output="$(terraform -chdir="$path" fmt -check -recursive 2>&1)" && status=0 || status=$?
+            echo "$output"
             echo "::endgroup::"
+            if [ "$status" -ne 0 ]; then
+              echo "::warning::Format issues in $path"
+              echo "$output"
+            fi
           done
 
   validate:
@@ -66,13 +71,16 @@ jobs:
           failed=""
           for path in $(echo "$PATHS_JSON" | jq -r '.[]'); do
             echo "::group::$path"
-            if ! (terraform -chdir="$path" init -backend=false && terraform -chdir="$path" validate); then
-              failed="$failed $path"
-            fi
+            output="$(terraform -chdir="$path" init -backend=false 2>&1 && terraform -chdir="$path" validate 2>&1)" && status=0 || status=$?
+            echo "$output"
             echo "::endgroup::"
+            if [ "$status" -ne 0 ]; then
+              failed="$failed $path"
+              echo "::error::$path failed validation:"
+              echo "$output" | grep -i -A2 'error'
+            fi
           done
           if [ -n "$failed" ]; then
-            echo "::error::Validation failed for:$failed"
             exit 1
           fi
 
@@ -116,13 +124,16 @@ jobs:
           failed=""
           for path in $(echo "$PATHS_JSON" | jq -r '.[]'); do
             echo "::group::$path"
-            if ! tflint --config /tmp/.tflint.hcl --chdir="$path"; then
-              failed="$failed $path"
-            fi
+            output="$(tflint --config /tmp/.tflint.hcl --chdir="$path" 2>&1)" && status=0 || status=$?
+            echo "$output"
             echo "::endgroup::"
+            if [ "$status" -ne 0 ]; then
+              failed="$failed $path"
+              echo "::error::$path has lint issues:"
+              echo "$output" | grep -i -A2 'error\|warning'
+            fi
           done
           if [ -n "$failed" ]; then
-            echo "::error::TFLint issues found in:$failed"
             exit 1
           fi
 
@@ -146,12 +157,15 @@ jobs:
           failed=""
           for path in $(echo "$PATHS_JSON" | jq -r '.[]'); do
             echo "::group::$path"
-            if ! trivy config --severity "$TRIVY_SEVERITY" --exit-code 1 "$path"; then
-              failed="$failed $path"
-            fi
+            output="$(trivy config --severity "$TRIVY_SEVERITY" --exit-code 1 "$path" 2>&1)" && status=0 || status=$?
+            echo "$output"
             echo "::endgroup::"
+            if [ "$status" -ne 0 ]; then
+              failed="$failed $path"
+              echo "::error::$path has security findings:"
+              echo "$output" | grep -i -A2 'failure\|critical\|high'
+            fi
           done
           if [ -n "$failed" ]; then
-            echo "::error::Trivy findings in:$failed"
             exit 1
           fi

--- a/.github/workflows/terraform-v1-ci.yml
+++ b/.github/workflows/terraform-v1-ci.yml
@@ -3,8 +3,8 @@ name: Terraform v1 CI
 on:
   workflow_call:
     inputs:
-      path:
-        description: "Path to Terraform 1.x directory"
+      paths:
+        description: "JSON array of paths to Terraform 1.x directories"
         type: string
         required: true
       terraform_version:
@@ -37,9 +37,15 @@ jobs:
         with:
           terraform_version: ${{ inputs.terraform_version }}
 
-      - name: Terraform Format Check
-        run: terraform fmt -check -recursive
-        working-directory: ${{ inputs.path }}
+      - name: Check formatting
+        env:
+          PATHS_JSON: ${{ inputs.paths }}
+        run: |
+          for path in $(echo "$PATHS_JSON" | jq -r '.[]'); do
+            echo "::group::$path"
+            terraform -chdir="$path" fmt -check -recursive || echo "::warning::Format issues in $path"
+            echo "::endgroup::"
+          done
 
   validate:
     name: Validate
@@ -53,13 +59,22 @@ jobs:
         with:
           terraform_version: ${{ inputs.terraform_version }}
 
-      - name: Initialize Terraform
-        run: terraform init -backend=false
-        working-directory: ${{ inputs.path }}
-
-      - name: Terraform Validate
-        run: terraform validate
-        working-directory: ${{ inputs.path }}
+      - name: Validate all paths
+        env:
+          PATHS_JSON: ${{ inputs.paths }}
+        run: |
+          failed=""
+          for path in $(echo "$PATHS_JSON" | jq -r '.[]'); do
+            echo "::group::$path"
+            if ! (terraform -chdir="$path" init -backend=false && terraform -chdir="$path" validate); then
+              failed="$failed $path"
+            fi
+            echo "::endgroup::"
+          done
+          if [ -n "$failed" ]; then
+            echo "::error::Validation failed for:$failed"
+            exit 1
+          fi
 
   tflint:
     name: TFLint
@@ -69,11 +84,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Write TFLint config
-        env:
-          TF_PATH: ${{ inputs.path }}
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v4
+
+      - name: Write config and initialize
         run: |
-          cat > "${TF_PATH}/.tflint.hcl" << 'TFLINT_EOF'
+          cat > /tmp/.tflint.hcl << 'TFLINT_EOF'
           plugin "terraform" {
             enabled = true
             preset  = "recommended"
@@ -91,17 +107,17 @@ jobs:
             version = "0.28.0"
           }
           TFLINT_EOF
+          tflint --init --config /tmp/.tflint.hcl
 
-      - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v4
-
-      - name: Initialize TFLint
-        run: tflint --init
-        working-directory: ${{ inputs.path }}
-
-      - name: Execute TFLint
-        run: tflint
-        working-directory: ${{ inputs.path }}
+      - name: Lint all paths
+        env:
+          PATHS_JSON: ${{ inputs.paths }}
+        run: |
+          for path in $(echo "$PATHS_JSON" | jq -r '.[]'); do
+            echo "::group::$path"
+            tflint --config /tmp/.tflint.hcl --chdir="$path" || echo "::warning::TFLint issues in $path"
+            echo "::endgroup::"
+          done
 
   trivy:
     name: Trivy
@@ -111,11 +127,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Trivy IaC Scan
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: "config"
-          scan-ref: ${{ inputs.path }}
-          severity: ${{ inputs.trivy_severity }}
-          exit-code: "0"
-          format: "table"
+      - name: Install Trivy
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+
+      - name: Scan all paths
+        env:
+          PATHS_JSON: ${{ inputs.paths }}
+          TRIVY_SEVERITY: ${{ inputs.trivy_severity }}
+        run: |
+          for path in $(echo "$PATHS_JSON" | jq -r '.[]'); do
+            echo "::group::$path"
+            trivy config --severity "$TRIVY_SEVERITY" --exit-code 1 "$path" || echo "::warning::Trivy findings in $path"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/terraform-v1-ci.yml
+++ b/.github/workflows/terraform-v1-ci.yml
@@ -1,0 +1,121 @@
+name: Terraform v1 CI
+
+on:
+  workflow_call:
+    inputs:
+      path:
+        description: "Path to Terraform 1.x directory"
+        type: string
+        required: true
+      terraform_version:
+        description: "Terraform version to install"
+        type: string
+        required: false
+        default: "1.5.0"
+      trivy_severity:
+        description: "Trivy severity threshold"
+        type: string
+        required: false
+        default: "HIGH,CRITICAL"
+      runner:
+        description: "Runner to use"
+        type: string
+        required: false
+        default: "ubuntu-latest"
+
+jobs:
+  format:
+    name: Format Check
+    runs-on: ${{ inputs.runner }}
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive
+        working-directory: ${{ inputs.path }}
+
+  validate:
+    name: Validate
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ inputs.terraform_version }}
+
+      - name: Initialize Terraform
+        run: terraform init -backend=false
+        working-directory: ${{ inputs.path }}
+
+      - name: Terraform Validate
+        run: terraform validate
+        working-directory: ${{ inputs.path }}
+
+  tflint:
+    name: TFLint
+    runs-on: ${{ inputs.runner }}
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Write TFLint config
+        env:
+          TF_PATH: ${{ inputs.path }}
+        run: |
+          cat > "${TF_PATH}/.tflint.hcl" << 'TFLINT_EOF'
+          plugin "terraform" {
+            enabled = true
+            preset  = "recommended"
+          }
+
+          plugin "aws" {
+            enabled = true
+            source  = "github.com/terraform-linters/tflint-ruleset-aws"
+            version = "0.30.0"
+          }
+
+          plugin "google" {
+            enabled = true
+            source  = "github.com/terraform-linters/tflint-ruleset-google"
+            version = "0.28.0"
+          }
+          TFLINT_EOF
+
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v4
+
+      - name: Initialize TFLint
+        run: tflint --init
+        working-directory: ${{ inputs.path }}
+
+      - name: Execute TFLint
+        run: tflint
+        working-directory: ${{ inputs.path }}
+
+  trivy:
+    name: Trivy
+    runs-on: ${{ inputs.runner }}
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Trivy IaC Scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "config"
+          scan-ref: ${{ inputs.path }}
+          severity: ${{ inputs.trivy_severity }}
+          exit-code: "0"
+          format: "table"

--- a/.github/workflows/terraform-v1-ci.yml
+++ b/.github/workflows/terraform-v1-ci.yml
@@ -113,11 +113,18 @@ jobs:
         env:
           PATHS_JSON: ${{ inputs.paths }}
         run: |
+          failed=""
           for path in $(echo "$PATHS_JSON" | jq -r '.[]'); do
             echo "::group::$path"
-            tflint --config /tmp/.tflint.hcl --chdir="$path" || echo "::warning::TFLint issues in $path"
+            if ! tflint --config /tmp/.tflint.hcl --chdir="$path"; then
+              failed="$failed $path"
+            fi
             echo "::endgroup::"
           done
+          if [ -n "$failed" ]; then
+            echo "::error::TFLint issues found in:$failed"
+            exit 1
+          fi
 
   trivy:
     name: Trivy
@@ -136,8 +143,15 @@ jobs:
           PATHS_JSON: ${{ inputs.paths }}
           TRIVY_SEVERITY: ${{ inputs.trivy_severity }}
         run: |
+          failed=""
           for path in $(echo "$PATHS_JSON" | jq -r '.[]'); do
             echo "::group::$path"
-            trivy config --severity "$TRIVY_SEVERITY" --exit-code 1 "$path" || echo "::warning::Trivy findings in $path"
+            if ! trivy config --severity "$TRIVY_SEVERITY" --exit-code 1 "$path"; then
+              failed="$failed $path"
+            fi
             echo "::endgroup::"
           done
+          if [ -n "$failed" ]; then
+            echo "::error::Trivy findings in:$failed"
+            exit 1
+          fi

--- a/docs/terraform-validation.md
+++ b/docs/terraform-validation.md
@@ -1,0 +1,162 @@
+# Terraform Validation CI
+
+Validates Terraform code on pull requests using static analysis. Supports both legacy Terraform 0.11 and modern Terraform 1.x codebases. No remote state, no plans — purely offline checks.
+
+## Quick Start
+
+1. Identify your Terraform directories and which version each uses
+2. Add the workflow calls to your repo's CI workflow (see examples below)
+3. Open a pull request — CI validates your Terraform code
+
+## Workflows
+
+### Terraform v0 (`terraform-v0-ci.yml`)
+
+For legacy Terraform 0.11 codebases.
+
+| Check | What it does | Blocks PR? |
+|-------|-------------|------------|
+| **Format Check** | `terraform fmt -check` | No (always green) |
+| **Validate** | `terraform init -backend=false` + `terraform validate -check-variables=false` | **Yes** |
+
+### Terraform v1 (`terraform-v1-ci.yml`)
+
+For modern Terraform 1.x codebases.
+
+| Check | What it does | Blocks PR? |
+|-------|-------------|------------|
+| **Format Check** | `terraform fmt -check -recursive` | No (always green) |
+| **Validate** | `terraform init -backend=false` + `terraform validate` | **Yes** |
+| **TFLint** | Lints against AWS and Google rulesets | No (orange on findings) |
+| **Trivy** | Scans for IaC security misconfigurations | No (orange on findings) |
+
+All checks run in parallel. Every directory is checked even when some fail — you see all issues at once.
+
+## Integration
+
+Add to your repo's CI workflow file (e.g. `.github/workflows/ci.yml`):
+
+### Repo with both v0 and v1
+
+```yaml
+jobs:
+  terraform-v0:
+    uses: fasttrack-solutions/ci/.github/workflows/terraform-v0-ci.yml@main
+    with:
+      paths: '["deployments/oneclick/terraform"]'
+
+  terraform-v1:
+    uses: fasttrack-solutions/ci/.github/workflows/terraform-v1-ci.yml@main
+    with:
+      paths: '["deployments/oneclick/terraform_v1"]'
+```
+
+### Repo with multiple v1 directories
+
+```yaml
+jobs:
+  terraform:
+    uses: fasttrack-solutions/ci/.github/workflows/terraform-v1-ci.yml@main
+    with:
+      paths: '["modules/clickhouse-instance", "modules/gcp-kms-module", "modules/gcp-wip-module"]'
+```
+
+### Repo with different Terraform versions per directory group
+
+```yaml
+jobs:
+  terraform-v1-default:
+    uses: fasttrack-solutions/ci/.github/workflows/terraform-v1-ci.yml@main
+    with:
+      paths: '["modules/clickhouse-instance", "modules/gcp-kms-module"]'
+
+  terraform-v1-custom:
+    uses: fasttrack-solutions/ci/.github/workflows/terraform-v1-ci.yml@main
+    with:
+      paths: '["modules/cubejs", "modules/traefik"]'
+      terraform_version: "1.7.0"
+```
+
+### Single directory
+
+```yaml
+jobs:
+  terraform:
+    uses: fasttrack-solutions/ci/.github/workflows/terraform-v1-ci.yml@main
+    with:
+      paths: '["infra/terraform"]'
+```
+
+## Inputs
+
+### `terraform-v0-ci.yml`
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `paths` | string | yes | — | JSON array of paths to Terraform 0.11 directories |
+| `runner` | string | no | `ubuntu-latest` | GitHub Actions runner to use |
+
+### `terraform-v1-ci.yml`
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `paths` | string | yes | — | JSON array of paths to Terraform 1.x directories |
+| `terraform_version` | string | no | `1.5.0` | Terraform version to install |
+| `trivy_severity` | string | no | `HIGH,CRITICAL` | Trivy severity threshold |
+| `runner` | string | no | `ubuntu-latest` | GitHub Actions runner to use |
+
+## How It Works
+
+### Path Input
+
+Paths are passed as a JSON array string. Each path is relative to your repository root:
+
+```yaml
+paths: '["deployments/terraform", "modules/networking", "modules/database"]'
+```
+
+All directories in a single workflow call share the same Terraform version. If you have directories that need different versions, make separate workflow calls.
+
+### Job Status Behavior
+
+The CI is designed to give clear visual feedback in the GitHub Actions UI:
+
+- **Format Check** — always green. Format issues appear in the logs but don't flag the job. Nothing is broken, just style.
+- **Validate** — red on failure. This is the hard gate — your Terraform code must be syntactically valid.
+- **TFLint** — orange when lint issues are found. Shows as a warning in the workflow summary without blocking merges.
+- **Trivy** — orange when security findings are found. Same non-blocking visibility as TFLint.
+
+### What Gets Checked
+
+**Format** checks that `.tf` files follow the canonical formatting. The v1 workflow checks recursively into subdirectories; v0 only checks the top-level directory (Terraform 0.11 limitation).
+
+**Validate** runs `terraform init -backend=false` (no remote state needed) followed by `terraform validate`. This catches syntax errors, missing required arguments, invalid resource configurations, and type mismatches. The v0 workflow uses `-check-variables=false` because 0.11 variables are provided at apply time via tfvars.
+
+**TFLint** (v1 only) runs the terraform, AWS, and Google linting rulesets. It catches issues like deprecated syntax, naming conventions, and provider-specific best practices. Repos not using AWS or Google providers simply won't trigger those rules.
+
+**Trivy** (v1 only) scans for IaC security misconfigurations — exposed ports, overly permissive IAM policies, unencrypted resources, etc. Only HIGH and CRITICAL severity findings are reported by default (configurable via `trivy_severity`).
+
+## Determining Your Terraform Version
+
+If you're unsure whether a directory uses v0 or v1:
+
+| Indicator | v0 (0.11) | v1 (1.x) |
+|-----------|-----------|----------|
+| Provider version syntax | `provider "aws" { version = "2.70" }` | `required_providers { aws = { source = "..." } }` |
+| Variable interpolation | `"${var.name}"` everywhere | `var.name` (no quotes needed) |
+| `terraform` block | Usually absent | Present with `required_providers` |
+| `-recursive` flag | Not supported | Supported |
+
+When in doubt, try the v1 workflow first — it covers more checks and most modern Terraform code is 1.x.
+
+## CI Files
+
+```
+.github/workflows/
+  terraform-v0-ci.yml    # Reusable workflow for Terraform 0.11
+  terraform-v1-ci.yml    # Reusable workflow for Terraform 1.x
+```
+
+## Deprecation
+
+When Terraform 0.11 is fully retired from your codebases, remove the `terraform-v0-ci.yml` calls from your workflows. No changes needed to v1.

--- a/docs/terraform-validation.md
+++ b/docs/terraform-validation.md
@@ -42,6 +42,7 @@ Add to your repo's CI workflow file (e.g. `.github/workflows/ci.yml`):
 jobs:
   terraform-v0:
     uses: fasttrack-solutions/ci/.github/workflows/terraform-v0-ci.yml@main
+    secrets: inherit
     with:
       paths: '["deployments/oneclick/terraform"]'
 
@@ -130,11 +131,15 @@ The CI is designed to give clear visual feedback in the GitHub Actions UI:
 
 **Format** checks that `.tf` files follow the canonical formatting. The v1 workflow checks recursively into subdirectories; v0 only checks the top-level directory (Terraform 0.11 limitation).
 
-**Validate** runs `terraform init -backend=false` (no remote state needed) followed by `terraform validate`. This catches syntax errors, missing required arguments, invalid resource configurations, and type mismatches. The v0 workflow uses `-check-variables=false` because 0.11 variables are provided at apply time via tfvars.
+**Validate** runs `terraform init -backend=false` (no remote state needed) followed by `terraform validate`. This catches syntax errors, missing required arguments, invalid resource configurations, and type mismatches. The v0 workflow uses `-check-variables=false` because 0.11 variables are provided at apply time via tfvars. The v0 validate job also builds a pinned Kubernetes Terraform provider from source (`fasttrack-solutions/terraform-provider-kubernetes`) to resolve a custom provider dependency used in legacy deployments — this requires `secrets: inherit` on the caller side for repository access.
 
 **TFLint** (v1 only) runs the terraform, AWS, and Google linting rulesets. It catches issues like deprecated syntax, naming conventions, and provider-specific best practices. Repos not using AWS or Google providers simply won't trigger those rules.
 
 **Trivy** (v1 only) scans for IaC security misconfigurations — exposed ports, overly permissive IAM policies, unencrypted resources, etc. Only HIGH and CRITICAL severity findings are reported by default (configurable via `trivy_severity`).
+
+## Secrets
+
+The v0 workflow clones a private repository (`fasttrack-solutions/terraform-provider-kubernetes`) during validation. Callers must pass `secrets: inherit` so the workflow has access to `GITHUB_TOKEN` for cross-repo cloning. The v1 workflow does not require any secrets.
 
 ## Determining Your Terraform Version
 


### PR DESCRIPTION
# Description

This PR adds the ability to run Terraform validation for tf0 or tf1 modules. Most checks are optional (like formatting, TFLint, and Trivy) however `terraform validate` must go green to merge the PR.

* Green run https://github.com/fasttrack-solutions/sms-distributor-go/actions/runs/24452648636?pr=352
* Validation failed run https://github.com/fasttrack-solutions/sms-distributor-go/actions/runs/24452661800?pr=352
 
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested on sms-distributor repository

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules