### PR TITLE
CORE-XXX :pirate_flag: :sparkles: fix(cache): include tag-prefix in …

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -135,8 +135,8 @@ runs:
           tags: ${{ steps.login-ecr.outputs.registry }}/${{inputs.image}}:${{inputs.tag-prefix}}oneclick-${{ env.BUILD_NUMBER }}-${{ steps.platform.outputs.arch }}
           file: ${{inputs.dockerfile}}
           build-args: ${{ inputs.build-args }}
-          cache-from: type=gha,scope=${{ inputs.image }}-${{ steps.platform.outputs.suffix }}
-          cache-to: type=gha,scope=${{ inputs.image }}-${{ steps.platform.outputs.suffix }},mode=max
+          cache-from: type=gha,scope=${{ inputs.image }}-${{ inputs.tag-prefix }}${{ steps.platform.outputs.suffix }}
+          cache-to:   type=gha,scope=${{ inputs.image }}-${{ inputs.tag-prefix }}${{ steps.platform.outputs.suffix }},mode=max
     - name: Build and push PR
       if: (github.ref != 'refs/heads/master' || github.ref != 'refs/heads/main') && steps.findPr.outputs.number > 0
       uses: docker/build-push-action@v6


### PR DESCRIPTION
…buildx cache scope

Parallel jobs calling this action with the same image input were sharing a single GHA cache scope and
  overwriting each other, so only one job persisted its cache per run. Adding tag-prefix to the scope isolates cache per job so all parallel builds hit cache on subsequent runs.

# Description

This pull request updates the Docker image build process in the GitHub Actions workflow to improve cache key uniqueness. The main change is the inclusion of the `tag-prefix` in the cache scope for both `cache-from` and `cache-to` options. This helps prevent cache conflicts between builds that use different tag prefixes.

**Build process improvements:**

* Updated the `cache-from` and `cache-to` parameters in `.github/actions/build-image/action.yml` to include `inputs.tag-prefix` in the cache scope, ensuring that Docker build caches are separated by tag prefix and reducing the risk of cache collisions.

Fixes # (issue jira/clickup task)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules