### PR TITLE
CORE-XXX :pirate_flag: :sparkles: fix(cache): include tag-prefix in b…

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -150,8 +150,8 @@ runs:
           tags: ${{ steps.login-ecr.outputs.registry }}/${{inputs.image}}:${{inputs.tag-prefix}}oneclickpr-${{ steps.findPr.outputs.pr }}-${{ env.BUILD_NUMBER }}-${{ steps.platform.outputs.arch }}
           file: ${{inputs.dockerfile}}
           build-args: ${{ inputs.build-args }}
-          cache-from: type=gha,scope=${{ inputs.image }}-${{ steps.platform.outputs.suffix }}
-          cache-to: type=gha,scope=${{ inputs.image }}-${{ steps.platform.outputs.suffix }},mode=max
+          cache-from: type=gha,scope=${{ inputs.image }}-${{ inputs.tag-prefix }}${{ steps.platform.outputs.suffix }}
+          cache-to: type=gha,scope=${{ inputs.image }}-${{ inputs.tag-prefix }}${{ steps.platform.outputs.suffix }},mode=max
     - name: Comment oneclick PR tag
       if: (github.ref != 'refs/heads/master' || github.ref != 'refs/heads/main') && steps.findPr.outputs.number > 0
       uses: marocchino/sticky-pull-request-comment@v2
@@ -174,5 +174,5 @@ runs:
           tags: ${{ steps.login-ecr.outputs.registry }}/${{inputs.image}}:${{inputs.tag-prefix}}oneclickrelease-${{ env.BUILD_NUMBER }}-${{ steps.platform.outputs.arch }}
           file: ${{inputs.dockerfile}}
           build-args: ${{ inputs.build-args }}
-          cache-from: type=gha,scope=${{ inputs.image }}-${{ steps.platform.outputs.suffix }}
-          cache-to: type=gha,scope=${{ inputs.image }}-${{ steps.platform.outputs.suffix }},mode=max
+          cache-from: type=gha,scope=${{ inputs.image }}-${{ inputs.tag-prefix }}${{ steps.platform.outputs.suffix }}
+          cache-to: type=gha,scope=${{ inputs.image }}-${{ inputs.tag-prefix }}${{ steps.platform.outputs.suffix }},mode=max


### PR DESCRIPTION
…uildx cache scope for PR and Release builds

Previous fix only updated the main/master block. PR and Release build steps still used a cache scope of image + platform suffix, so parallel jobs in the same repo that share an image but differ in tag-prefix (e.g. api-, consumers-, report-) competed for the same GHA cache key. Only one job cached between runs while the others rebuilt cold. Adding tag-prefix to the scope in the PR and Release blocks makes each job cache independently, matching the main/master block fixed in #73.

# Description

This pull request updates the Docker image build caching configuration in the GitHub Actions workflow to include the `tag-prefix` in the cache scope. This change helps ensure that build caches are properly segmented by tag prefix, reducing the risk of cache collisions between different image tags.

**Build caching improvements:**

* Updated the `cache-from` and `cache-to` parameters in `.github/actions/build-image/action.yml` to include `${{ inputs.tag-prefix }}` in the cache scope for both PR and release image builds. [[1]](diffhunk://#diff-ff9ef09a611caef7f76d1b466ff6ad4ec28506e7d4dc74680bed28bdb942b0d6L153-R154) [[2]](diffhunk://#diff-ff9ef09a611caef7f76d1b466ff6ad4ec28506e7d4dc74680bed28bdb942b0d6L177-R178)

Fixes # (issue jira/clickup task)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules