### PR TITLE
fix(comment): move OneClick PR tag sticky into create-manifest

### DIFF
--- a/.github/actions/build-publish-docker/action.yml
+++ b/.github/actions/build-publish-docker/action.yml
@@ -189,15 +189,6 @@ runs:
             ${{ inputs.build-args }}
         cache-from: type=gha,scope=${{ inputs.image }}-${{ inputs.tag-prefix }}${{ steps.platform.outputs.suffix }}
         cache-to: type=gha,scope=${{ inputs.image }}-${{ inputs.tag-prefix }}${{ steps.platform.outputs.suffix }},mode=max
-    - name: Comment oneclick PR tag
-      if: (github.ref != 'refs/heads/master' || github.ref != 'refs/heads/main') && steps.findPr.outputs.number > 0
-      uses: marocchino/sticky-pull-request-comment@v2
-      with:
-        GITHUB_TOKEN: ${{ inputs.github_token }}
-        header: OneClick PR tag
-        recreate: true
-        message: |
-          Your build has the image tag: `${{inputs.tag-prefix}}oneclickpr-${{ steps.findPr.outputs.pr }}-${{ env.BUILD_NUMBER }}` :sparkles:
     - name: Build and push Release
       if: contains(github.ref, 'release')
       uses: docker/build-push-action@v6

--- a/.github/actions/create-manifest/action.yml
+++ b/.github/actions/create-manifest/action.yml
@@ -126,6 +126,15 @@ runs:
         echo "Successfully pushed manifest: ${MANIFEST_IMAGE}"
         docker manifest inspect "${MANIFEST_IMAGE}"
 
+    - name: Comment oneclick PR tag
+      if: github.event_name == 'pull_request' && steps.findPr.outputs.number > 0 && inputs.github_token != ''
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        header: "OneClick PR tag - ${{ inputs.image }}${{ inputs.tag-prefix != '' && format('-{0}', inputs.tag-prefix) || '' }}"
+        message: |
+          Your build has the image tag: `${{ inputs.tag-prefix }}oneclickpr-${{ steps.findPr.outputs.pr }}-${{ env.BUILD_NUMBER }}` :sparkles:
+
     - name: Create and push latest manifest
       if: inputs.latest_tag == 'true'
       shell: bash

--- a/.github/workflows/docker-service.yml
+++ b/.github/workflows/docker-service.yml
@@ -84,6 +84,9 @@ jobs:
   create-manifest:
     needs: build-service
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Create multi-arch manifest
         uses: fasttrack-solutions/ci/.github/actions/create-manifest@main
@@ -96,4 +99,5 @@ jobs:
           dockerhub_pull_token: ${{ secrets.DOCKERHUB_PULL_TOKEN }}
           latest_tag: ${{ inputs.latest_tag }}
           tag-prefix: ${{ inputs.tag-prefix }}
-          multi_arch: ${{ inputs.multi_arch }}          
+          multi_arch: ${{ inputs.multi_arch }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the GraphQL `Could not resolve to a node with the global id of 'IC_kwDO...'` error that started showing up in `activitymanager-go` CI after enabling multi-arch builds (see fasttrack-solutions/activitymanager-go#460).

## What was happening

The sticky-pull-request-comment step lived inside `build-publish-docker/action.yml`, which is invoked **once per matrix job** (per arch) per service. With `multi_arch: true` enabled and a repo like `activitymanager-go` that builds 8 services, that's 8 × 2 = **16 jobs** all using the same hard-coded header `"OneClick PR tag"` with `recreate: true`.

`recreate: true` does *delete-then-create* via the GraphQL `deleteIssueComment` mutation. When two parallel jobs each pull the same comment node ID, the first job deletes it, then the second job's delete fails with "Could not resolve to a node with the global id of '<comment-node-id>'" — that `IC_…` prefix is a GraphQL Issue-Comment node ID.

This race technically existed even before multi-arch (8 services already raced), but doubling the parallelism exposed it.

## Fix

1. **Move the comment step out of `build-publish-docker`** (per-arch / per-matrix-job) and into **`create-manifest`** (once per service, after the matrix finishes). This eliminates the intra-service arch race entirely.
2. **Namespace the sticky header by `image` + `tag-prefix`** (e.g. `OneClick PR tag - activitymanager-go-live-`). Each service variant now owns its own sticky comment, so concurrent service builds no longer fight for the same comment node.
3. **Drop `recreate: true`** — with unique headers there's only ever one writer, so the action's default update-in-place is race-safe and avoids the delete-then-create dance.
4. **Wire `github_token` and `pull-requests: write` through `docker-service.yml`** so the comment step has the perms it needs. Comment posting is gated behind `inputs.github_token != ''`, so callers that don't pass a token simply skip it (no behavior change for them).

## Trade-off (worth flagging)

Repos that build a single image (the common case) still get exactly 1 sticky comment.

Repos that build many services from one workflow (like activitymanager-go with 8 services) will now get **N stable sticky comments instead of 1 racing/flapping comment**. The previous "single comment" behavior was already lossy: whichever service won the last race overwrote everyone else's tag, so the comment was misleading. The new behavior shows the tag for every service.

If we later want one consolidated comment, the right place is a downstream summary job in the consuming workflow (similar to how `rewards-backend` does it), not inside the shared per-service action.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## Testing

- [ ] Re-run CI for fasttrack-solutions/activitymanager-go#460 (uses `@main`) — confirm no `IC_kwDO...` errors
- [ ] Confirm a sticky comment is posted per service variant in that PR
- [ ] Confirm a single-service repo (e.g. one of the smaller services using `docker-service.yml`) still posts exactly 1 sticky comment
- [ ] Confirm pushes to `master`/`main` do not post a comment (gate is `github.event_name == 'pull_request'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)