### PR TITLE
ci: switch arm64 runner label to standard ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/docker-api-service.yml
+++ b/.github/workflows/docker-api-service.yml
@@ -53,7 +53,7 @@ jobs:
     name: ${{ matrix.platform == 'linux/arm64' && 'build-service-arm64' || 'build-service' }}
     strategy:
       matrix:
-        include: ${{ fromJSON(inputs.multi_arch && '[{"platform":"linux/amd64","runner":"ubuntu-latest"},{"platform":"linux/arm64","runner":"ubuntu-arm64-latest"}]' || '[{"platform":"linux/amd64","runner":"ubuntu-latest"}]') }}
+        include: ${{ fromJSON(inputs.multi_arch && '[{"platform":"linux/amd64","runner":"ubuntu-latest"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm"}]' || '[{"platform":"linux/amd64","runner":"ubuntu-latest"}]') }}
     runs-on: ${{ matrix.runner }}
     steps:
     - name: Build & Publish
@@ -76,7 +76,7 @@ jobs:
     name: ${{ matrix.platform == 'linux/arm64' && 'build-api-arm64' || 'build-api' }}
     strategy:
       matrix:
-        include: ${{ fromJSON(inputs.multi_arch && '[{"platform":"linux/amd64","runner":"ubuntu-latest"},{"platform":"linux/arm64","runner":"ubuntu-arm64-latest"}]' || '[{"platform":"linux/amd64","runner":"ubuntu-latest"}]') }}
+        include: ${{ fromJSON(inputs.multi_arch && '[{"platform":"linux/amd64","runner":"ubuntu-latest"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm"}]' || '[{"platform":"linux/amd64","runner":"ubuntu-latest"}]') }}
     runs-on: ${{ matrix.runner }}
     steps:
     - name: Build & Publish

--- a/.github/workflows/docker-service-build.yml
+++ b/.github/workflows/docker-service-build.yml
@@ -53,7 +53,7 @@ jobs:
     name: ${{ matrix.platform == 'linux/arm64' && 'build-service-arm64' || 'build-service' }}
     strategy:
       matrix:
-        include: ${{ fromJSON(inputs.multi_arch && '[{"platform":"linux/amd64","runner":"ubuntu-latest"},{"platform":"linux/arm64","runner":"ubuntu-arm64-latest"}]' || '[{"platform":"linux/amd64","runner":"ubuntu-latest"}]') }}
+        include: ${{ fromJSON(inputs.multi_arch && '[{"platform":"linux/amd64","runner":"ubuntu-latest"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm"}]' || '[{"platform":"linux/amd64","runner":"ubuntu-latest"}]') }}
     runs-on: ${{ matrix.runner }}
     steps:
     - name: Build & Publish

--- a/.github/workflows/docker-service.yml
+++ b/.github/workflows/docker-service.yml
@@ -58,7 +58,7 @@ jobs:
     name: ${{ matrix.platform == 'linux/arm64' && 'build-service-arm64' || 'build-service' }}
     strategy:
       matrix:
-        include: ${{ fromJSON(inputs.multi_arch && '[{"platform":"linux/amd64","runner":"ubuntu-latest"},{"platform":"linux/arm64","runner":"ubuntu-arm64-latest"}]' || '[{"platform":"linux/amd64","runner":"ubuntu-latest"}]') }}
+        include: ${{ fromJSON(inputs.multi_arch && '[{"platform":"linux/amd64","runner":"ubuntu-latest"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm"}]' || '[{"platform":"linux/amd64","runner":"ubuntu-latest"}]') }}
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Build & Publish


### PR DESCRIPTION
## Summary

Swap the arm64 leg of every Docker build matrix from the partner-image runner `ubuntu-arm64-latest` (Arm Limited managed) to the standard GitHub-hosted runner `ubuntu-24.04-arm`.

The partner-image runner stopped accepting jobs after the GitHub Enterprise migration in this org — jobs sit indefinitely in \`Waiting for a runner to pick up this job\` even with the runner in the Default group with All organizations / All workflows access. Smoke-tested \`ubuntu-24.04-arm\` on the gamerounder branch and it picks up + runs to completion immediately.

## Changes

- \`docker-service.yml\` — arm64 leg → \`ubuntu-24.04-arm\`
- \`docker-service-build.yml\` — arm64 leg → \`ubuntu-24.04-arm\`
- \`docker-api-service.yml\` — both build-service and build-api matrices → \`ubuntu-24.04-arm\`

Total diff: 4 lines across 3 files.

## Why this is safe

- \`ubuntu-24.04-arm\` is a [standard GitHub-hosted runner GA'd for private repos in January 2026](https://github.blog/changelog/2026-01-29-arm64-standard-runners-are-now-available-in-private-repositories/).
- First-party (not partner) — no separate SLA gap, no Arm Limited dependency.
- Free-tier eligible; usage counts against the org's standard runner minutes.
- No org/enterprise enablement steps required (confirmed via smoke test).

## Verification

[gamerounder smoke run](https://github.com/fasttrack-solutions/gamerounder/actions/runs/25752274459) — arm64-smoke.yml with \`runs-on: ubuntu-24.04-arm\` completed successfully.

## Follow-up

Once this merges and downstream repos pick up the new shared workflow, the partner \`ubuntu-arm64-latest\` runner can be removed from the org runner group entirely.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)